### PR TITLE
Add link to Code of Conduct in footer

### DIFF
--- a/tokyo-2024/config.toml
+++ b/tokyo-2024/config.toml
@@ -160,4 +160,7 @@ InnerSource Commons は、InnerSource のグローバルコミュニティです
 InnerSource の始め方やベストプラクティスを共有し、InnerSource の価値観や原則についての議論を促進しています。
 """
 # copyright
-copyright = "Copyright &copy; 2024"
+copyright = """
+[行動規範](https://innersourcecommons.org/ja/about/codeofconduct/)<br>
+Copyright &copy; 2024
+"""


### PR DESCRIPTION
Commons のホームページに日本語版の行動規範があったのでそのページへのリンクを追加しました。
https://innersourcecommons.org/ja/about/codeofconduct/

テーマの構造上、Footer にリンクを追加する場合、copyright の部分に工夫してねじ込む必要がありましたのでそうしています。