### PR TITLE
Priceに関する表示を削除

### DIFF
--- a/tokyo-2024/config.toml
+++ b/tokyo-2024/config.toml
@@ -66,11 +66,6 @@ link = "plugins/google-map/map.js"
 
     [[menu.main]]
     parent = "Pages"
-    name = "Tickets"
-    URL = "pricing"
-
-    [[menu.main]]
-    parent = "Pages"
     name = "Blog"
     URL = "blog"
 

--- a/tokyo-2024/data/en/homepage.yml
+++ b/tokyo-2024/data/en/homepage.yml
@@ -71,7 +71,7 @@ schedule:
 
 ####################### pricing #############################
 pricing:
-  enable : true
+  enable : false
   # pricing data comes from "pricing.yml" file
 
 ########################## speaker ##########################

--- a/tokyo-2024/data/en/pricing.yml
+++ b/tokyo-2024/data/en/pricing.yml
@@ -7,7 +7,7 @@ timer:
 
 ################################# Pricing ##########################
 pricing:
-  enable : true
+  enable: false
   title_outline : "Price"
   title : "Get your Ticket"
   content : "Accusantium provident suscipit dicta magni dolor deserunt nam obcaecati non veritatis optio."


### PR DESCRIPTION
## 変更内容

無償開催ということで価格表示が不要なので、非表示にしました

- homepageでのPriceセクションを非表示に
- menuでのリンクを削除

## ご相談事項

リンクは消しましたが、テーマの都合上、`/pricing/`のページ自体は残ってしまいそうなのですがどうしましょうか...
 
- テーマから消す(テーマを共有する他サイトに影響が...)
- ページが残ることを許容
- ページを再利用して、無料です！的な内容を書いておく

くらいが選択肢かなあと思っています

close #34