### PR TITLE
タイトル部分にWebフォントを指定

### DIFF
--- a/themes/gathering-theme/assets/scss/_about.scss
+++ b/themes/gathering-theme/assets/scss/_about.scss
@@ -19,9 +19,11 @@
 	}
 }
 
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap');
+
 .stroke-text {
 	color: #fff;
-	font-family: sans-serif;
+	font-family: "Roboto", sans-serif;
 	-webkit-text-stroke-width: 1px;
 	-webkit-text-stroke-color: #0aa8a7;
 	font-size: 120px;


### PR DESCRIPTION
## 概要

一部フォントでは`text-stroke`の表示がおかしくなってしまうため、タイトル部分だけWebフォントを使用してフォントを固定

(多分メジャーだろうと思われる & アルファベットしか使われないはず、ということでGoogle FontからRobotoを指定しています)