### PR TITLE
Feat/add tickets embed to Berlin 2025 gathering

### DIFF
--- a/berlin-2025/data/en/homepage.yml
+++ b/berlin-2025/data/en/homepage.yml
@@ -19,6 +19,10 @@ timer:
   day: "12"
   hour: "12"
 
+tickets:
+  enable: true
+  url: "https://tickets.plainschwarz.com/ISCG25/"
+
 ############################## Event ##############################
 event:
   enable: true

--- a/berlin-2025/data/en/homepage.yml
+++ b/berlin-2025/data/en/homepage.yml
@@ -3,7 +3,7 @@ banner:
   enable : true
   title : "InnerSource Gathering Berlin 2025"
   bg_image: "images/berlin.jpg"
-  date_time : "Jan 13, 2025"
+  date_time : "Mar 12, 2025"
   button:
     enable : false
     label : "Discover more"

--- a/themes/gathering-theme/layouts/index.html
+++ b/themes/gathering-theme/layouts/index.html
@@ -49,6 +49,26 @@
 {{ end }}
 <!-- /timer -->
 
+<!-- tickets purchase embed -->
+
+{{ if $data.homepage.tickets.enable }}
+<div class="container">
+  <div class="about-content-wrap mt-5 mt-lg-0">
+  {{ with $data.homepage.tickets }}
+  <pretix-widget event="{{ .url }}" single-item-select="button"></pretix-widget>
+  <noscript>
+    <div class="pretix-widget">
+          <div class="pretix-widget-info-message">
+              JavaScript ist in Ihrem Browser deaktiviert. Um unseren Ticketshop ohne JavaScript aufzurufen, klicken Sie bitte <a target="_blank" rel="noopener" href="{{ .url }}">hier</a>.
+          </div>
+      </div>
+  </noscript>
+  {{ end }}
+  </div>
+</div>
+{{ end }}
+<!-- /tickets purchase embed -->
+
 <!-- event  -->
 {{ if $data.homepage.event.enable }}
 {{ partial "event.html" . }}
@@ -299,6 +319,14 @@
 {{ end }}
 
 <!-- /past_item -->
+
+{{ if $data.homepage.tickets.enable }}
+<div class="container">
+  <div class="about-content-wrap mt-5 mt-lg-0">
+    Within our web page, we use features and content embedded from pretix, a service provided by rami.io GmbH, Berthold-Mogel-Straße 1, 69126 Heidelberg, Germany. Part of this is our ticket shop which is included through a JavaScript widget. If you try to purchase a ticket, pretix will use cookies to make your purchase process possible and to remember which tickets are in your cart. This cookie will only be set once you start interacting with the pretix widget. pretix does not store any IP addresses, browser information or other unnecessary meta data beyond the timeframe of your transaction. You can find out more about privacy at pretix here: <a href="https://pretix.eu/about/en/privacy">https://pretix.eu/about/en/privacy</a>
+  </div>
+</div>
+{{ end }}
 
 <div class="mb-5"></div>
 

--- a/themes/gathering-theme/layouts/partials/head.html
+++ b/themes/gathering-theme/layouts/partials/head.html
@@ -1,3 +1,5 @@
+{{ $data := index .Site.Data .Site.Language.Lang }}
+
 <head>
   <meta charset="utf-8">
   <title>{{ .Title }}</title>
@@ -30,6 +32,11 @@
 
     gtag('config', 'G-N2LHBZY3MV');
   </script>
+
+  {{ if $data.homepage.tickets.enable }}
+  <link rel="stylesheet" type="text/css" href="https://tickets.plainschwarz.com/ISCG25/widget/v1.css" crossorigin>
+  <script type="text/javascript" src="https://tickets.plainschwarz.com/widget/v1.en.js" async crossorigin></script>
+  {{ end }}
 
   {{ template "_internal/opengraph.html" . }}
   {{ template "_internal/twitter_cards.html" . }}


### PR DESCRIPTION
Adds the ticket embed to the Berlin gathering page and also fixes the date. Enables other pages to add the embed with a dynamic link

![FireShot Capture 001 - InnerSource Gathering Berlin 2025 - localhost](https://github.com/user-attachments/assets/e2b0010a-705d-4fe1-b134-9ccac9274952)
