### PR TITLE
Fix heading `text-stroke` font showing unxexpected behavior

### DIFF
--- a/themes/gathering-theme/assets/scss/_about.scss
+++ b/themes/gathering-theme/assets/scss/_about.scss
@@ -22,13 +22,14 @@
 .stroke-text {
 	color: #fff;
 	font-family: sans-serif;
-	-webkit-text-stroke-width: 1px;
+	-webkit-text-stroke-width: 2px;
 	-webkit-text-stroke-color: #0aa8a7;
 	font-size: 120px;
 	font-weight: 800;
 	text-transform: uppercase;
 	line-height: 1;
 	-webkit-text-fill-color: #fff;
+	paint-order: stroke fill;
 
 	@include tablet {
 		font-size: 90px;

--- a/themes/gathering-theme/assets/scss/_about.scss
+++ b/themes/gathering-theme/assets/scss/_about.scss
@@ -19,18 +19,15 @@
 	}
 }
 
-@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap');
-
 .stroke-text {
 	color: #fff;
-	font-family: "Roboto", sans-serif;
+	font-family: sans-serif;
 	-webkit-text-stroke-width: 1px;
 	-webkit-text-stroke-color: #0aa8a7;
 	font-size: 120px;
 	font-weight: 800;
 	text-transform: uppercase;
 	line-height: 1;
-	// なぜかフォントの協会が被ってしまう全部白にできないか
 	-webkit-text-fill-color: #fff;
 
 	@include tablet {


### PR DESCRIPTION
## Summary

This PR fixes the font rendering of headings from:

<img width="620" alt="before" src="https://github.com/user-attachments/assets/703c80a7-8f92-4f99-a0d7-873704cbf4c7" />

to:

<img width="706" alt="after" src="https://github.com/user-attachments/assets/642a3ec5-0cb8-4ad9-8388-4e8d22ad060a" />

## Cause

This PR reverts the changes made in #53 and introduces an alternative solution.

It's known issue that `--webkit-text-stroke`, when used with certain Variable Font, can cause unexpected rendering.
This issue occurs on some devices (e.g., Android: Noto Sans JP) where a Variable Font was used as sans-serif.

The original change attempted to fix this by switching the font to Roboto. However, since Roboto has also become a Variable Font, the same problem now occurs on all devices.

This PR reverts the previous solution and instead addresses the issue by rendering the `fill` after the `stroke`.
